### PR TITLE
refactor!: rely on runtimeConfig for build-time configuration

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,5 +1,12 @@
 export default defineNuxtConfig({
   modules: ['../src/module'],
   myModule: {},
-  devtools: { enabled: true }
+  devtools: { enabled: true },
+  runtimeConfig:{
+    public: {
+      applicationinsights: {
+        connectionString: ''
+      }
+    }
+  }
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -17,8 +17,6 @@ export interface ApplicationInsightModuleOptions {
    * Enable client side application insights with @microsoft/applicationinsights-web
    */
   clientEnabled: boolean
-  serverConfig?: Partial<TNitroAppInsightsConfig>
-  clientConfig?: Partial<Snippet>
 }
 
 export default defineNuxtModule<ApplicationInsightModuleOptions>({
@@ -33,18 +31,6 @@ export default defineNuxtModule<ApplicationInsightModuleOptions>({
   },
   async setup(options, nuxt) {
     const resolver = createResolver(import.meta.url)
-
-    nuxt.options.runtimeConfig.applicationinsights = defu(nuxt.options.runtimeConfig.applicationinsights || {},      
-      Object.assign({}, { connectionString: options.connectionString }, options.serverConfig) as Partial<TNitroAppInsightsConfig>
-    )
-
-    nuxt.options.runtimeConfig.public.applicationinsights = defu(nuxt.options.runtimeConfig.public.applicationinsights || {},      
-       options.clientConfig, {
-        config: {
-          connectionString: options.connectionString
-        }
-       } as Partial<Snippet>
-    )
 
     addTypeTemplate({
       filename: 'types/nuxt-applicationinsights.d.ts',

--- a/src/runtime/app/plugin.client.ts
+++ b/src/runtime/app/plugin.client.ts
@@ -7,7 +7,6 @@ import { generateW3CId } from "@microsoft/applicationinsights-core-js"
 import { INITIAL_TRACE_KEY } from "./utils"
 // @ts-expect-error virtual file
 import { baseURL } from "#build/paths.mjs"
-import { defu } from "defu"
 
 export default defineNuxtPlugin({
     name: 'nuxt-applicationinsights:client',
@@ -15,14 +14,14 @@ export default defineNuxtPlugin({
         const runtimeConfig = useRuntimeConfig()
         const route = useRoute()
         const config: Snippet = {
-            config: {}
+            config: runtimeConfig.public.applicationinsights ?? {}
         }
 
         await nuxtApp.callHook('applicationinsights:config:client', config)
 
         // @ts-expect-error
         delete globalThis.$fetch
-        const applicationInsights = new ApplicationInsights(defu(config, toRaw(runtimeConfig.public.applicationinsights as Snippet)))
+        const applicationInsights = new ApplicationInsights(config)
 
         applicationInsights.loadAppInsights()
         applicationInsights.addDependencyListener(dep => {

--- a/src/runtime/server/plugins/setup.ts
+++ b/src/runtime/server/plugins/setup.ts
@@ -1,10 +1,13 @@
 import { type NitroAppPlugin } from 'nitropack'
 import { useRuntimeConfig } from '#imports'
+import { defu } from 'defu'
 
 export default <NitroAppPlugin>((nitro) => {
     const runtimeConfig = useRuntimeConfig()
-    
+
     nitro.hooks.hook('applicationinsights:config', (config) => {
-        Object.assign(config, runtimeConfig.applicationinsights)
+        Object.assign(config, defu(runtimeConfig.applicationinsights, {
+            connectionString: runtimeConfig.public.applicationinsights?.connectionString
+        }))
     })
 })

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -8,7 +8,7 @@ declare module '@nuxt/schema' {
     }
 
     interface PublicRuntimeConfig {
-        applicationinsights: Partial<Snippet>
+        applicationinsights: Partial<Snippet['config']>
     }
 
 }


### PR DESCRIPTION
# This PR brings breaking changes !

resolve #41 

## this doesn't change anythings for users relying on nitro and nuxt hooks

### Important
Nitro will now fallback on `runtimeConfig.public.applicationinsights.connectionString` if it exist

Migration steps:
- the module options does not contains the configuration anymore
- to set the configuration at build time, use the runtimeConfig
- the public applicationInsight config now directly accept `IConfiguration & IConfig` instead of `Snippet`: move `runtimeConfig.public.applicationinsights.config` to `runtimeConfig.public.applicationinsights`


