### PR TITLE
fix: stop grouping all operations within a single id

### DIFF
--- a/src/runtime/app/plugin.client.ts
+++ b/src/runtime/app/plugin.client.ts
@@ -1,10 +1,9 @@
 import { defineNuxtPlugin } from "nuxt/app";
 import { ApplicationInsights, } from "@microsoft/applicationinsights-web";
 import type { Snippet } from "@microsoft/applicationinsights-web";
-import { useRuntimeConfig, toRaw, useRouter, useRoute } from "#imports";
+import { useRuntimeConfig } from "#imports";
 import { createFetch } from "ofetch"
-import { generateW3CId } from "@microsoft/applicationinsights-core-js"
-import { INITIAL_TRACE_KEY } from "./utils"
+
 // @ts-expect-error virtual file
 import { baseURL } from "#build/paths.mjs"
 
@@ -12,50 +11,22 @@ export default defineNuxtPlugin({
     name: 'nuxt-applicationinsights:client',
     async setup(nuxtApp) {
         const runtimeConfig = useRuntimeConfig()
-        const route = useRoute()
         const config: Snippet = {
             config: runtimeConfig.public.applicationinsights ?? {}
         }
 
         await nuxtApp.callHook('applicationinsights:config:client', config)
 
-        // @ts-expect-error
-        delete globalThis.$fetch
         const applicationInsights = new ApplicationInsights(config)
 
         applicationInsights.loadAppInsights()
-        applicationInsights.addDependencyListener(dep => {
-            dep.traceId = nuxtApp.payload.data[INITIAL_TRACE_KEY].split('-')[1]
-        })
-        applicationInsights.addTelemetryInitializer((item) => {
-            if (!item.tags) { item.tags = [] }
 
-            if (item.baseType === 'PageviewData' || item.baseType === 'PageviewPerformanceData') {
-                delete item.tags['ai.operation.parentId']
-                item.tags['ai.operation.id'] = nuxtApp.payload.data[INITIAL_TRACE_KEY].split('-')[1]
-            } else {
-                item.tags['ai.operation.parentId'] = applicationInsights.context.telemetryTrace.traceID
-            }
-            item.tags['ai.operation.id'] = nuxtApp.payload.data[INITIAL_TRACE_KEY].split('-')[1]
-        })
-        applicationInsights.context.telemetryTrace.traceID = generateW3CId()
-
+        // @ts-expect-error
+        delete globalThis.$fetch
         globalThis.$fetch = createFetch({
             defaults: {
                 baseURL: baseURL()
             }
-        })
-
-        const router = useRouter()
-        // TODO give users the choice between route name and route matched path
-        applicationInsights.trackPageView({ name: route.name as string })
-        nuxtApp.hook('app:mounted', () => {
-            router.beforeResolve((to) => {
-                applicationInsights.context.telemetryTrace.traceID = generateW3CId()
-                // TODO give users the choice between route name and route matched path
-                applicationInsights.trackPageView({ name: to.name as string })
-                applicationInsights.flush()
-            })
         })
 
         return {

--- a/src/runtime/app/plugin.server.ts
+++ b/src/runtime/app/plugin.server.ts
@@ -16,8 +16,6 @@ export default defineNuxtPlugin<{
     name: 'nuxt-applicationinsights:server',
     enforce: "pre",
     setup(nuxtApp) {
-        nuxtApp.payload.data[INITIAL_TRACE_KEY] = nuxtApp.ssrContext!.event.$appInsights.initialTrace
-
         return {
             provide: {
                 appInsights: nuxtApp.ssrContext!.event.$appInsights


### PR DESCRIPTION
Currently the behavior is to link all pageView and request under a same ID.

This PR reverts this behavior to let application insights handle this.