### PR TITLE
feat: applicationinsights:load:error hook

### DIFF
--- a/src/runtime/app/plugin.client.ts
+++ b/src/runtime/app/plugin.client.ts
@@ -18,16 +18,19 @@ export default defineNuxtPlugin({
 
         const applicationInsights = new ApplicationInsights(config)
 
-        applicationInsights.loadAppInsights()
+        try {
+            applicationInsights.loadAppInsights()
 
-        // @ts-expect-error
-        delete globalThis.$fetch
-        globalThis.$fetch = createFetch({
-            defaults: {
-                baseURL: baseURL()
-            }
-        })
-
+            // @ts-expect-error
+            delete globalThis.$fetch
+            globalThis.$fetch = createFetch({
+                defaults: {
+                    baseURL: baseURL()
+                }
+            })
+        } catch(e) {
+           nuxtApp.callHook("applicationinsights:load:error", e as Error) 
+        }
         return {
             provide: {
                 appInsights: applicationInsights

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -16,6 +16,7 @@ declare module 'nuxt/schema' {
 declare module '#app/nuxt' {
     interface RuntimeNuxtHooks {
         'applicationinsights:config:client': (config: Snippet) => void
+        'applicationinsights:load:error': (error: Error) => void
     }
 }
 


### PR DESCRIPTION
fix #85 

prevent the app to crash when loading app insights and add a new hook when app insights fails to load