### PR TITLE
fix: augment `nuxt/schema` instead of `@nuxt/schema`

### DIFF
--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -2,7 +2,7 @@ import type { Snippet } from "@microsoft/applicationinsights-web";
 import type { TNitroAppInsightsConfig } from "nitro-applicationinsights";
 
 
-declare module '@nuxt/schema' {
+declare module 'nuxt/schema' {
     interface RuntimeConfig {
         applicationinsights: Partial<TNitroAppInsightsConfig>
     }


### PR DESCRIPTION
fix #110 

This is a temporary fix while awaiting a proper reproduction and a decision on Nuxt side. 

So far, it seems that this happens randomly with yarn and npm (locally on mine with windows). It always happens on the reproduction provided in the issue. 

Seems like `nuxt-applicationinsights` type augmentation conflicts with `@nuxt/schema`. `NitroRuntimeConfig` is fully overriden by the type augmentations in stackblitz while locally, `NitroRuntimeConfig` isn't augmented at all.